### PR TITLE
Support AMD imports with baseUrl and without paths in ts config

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -134,9 +134,9 @@ const tests: Record<string, Test> = {
     error: "Could not find a valid 'tsconfig.json'",
   },
   ["should error with no 'paths' in config"]: {
-    options: { config: { ...config, paths: undefined } },
+    options: { config: { paths: undefined, baseUrl: undefined } },
     path: './src/pages/Page.ts',
-    error: "Unable to find the 'paths' property in the supplied configuration!",
+    error: "Unable to find the 'paths' or 'baseUrl' property in the supplied configuration!",
   },
   ["should error with no 'path' supplied"]: {
     options: { config },
@@ -144,6 +144,24 @@ const tests: Record<string, Test> = {
     input: '',
     output: '',
     error: 'Received file with no path. Files must have path to be resolved.',
+  },
+  ['should replace to relative path when config with baseUrl but without Paths']: {
+    options: { config: { baseUrl: './src' } },
+    path: './src/pages/Page.ts',
+    input: "import {Grid} from 'components/grid'",
+    output: "import {Grid} from '../components/grid'",
+  },
+  ['should ignore node module']: {
+    options: { config: { baseUrl: './src' } },
+    path: './src/pages/Page.ts',
+    input: "import File from 'vinyl'",
+    output: "import File from 'vinyl'",
+  },
+  ['should ignore builtin module']: {
+    options: { config: { baseUrl: './src' } },
+    path: './src/pages/Page.ts',
+    input: "import assert from 'assert'",
+    output: "import assert from 'assert'",
   },
 }
 


### PR DESCRIPTION
for example i have ts config:

```js
{"compilerOptions": {
  "baseUrl": "./src"
}}
```
and have two source files
```js
// pages/MainPage.ts
import {Grid} from "core/Grid";

```
```js
// core/Grid.ts
export class Grid {}
```

i need to resolve import path in pages/MainPage.ts
from "core/Grid" to "../core/Grid"
because i have baseUrl in ts config and typescript understand types by path "core/Grid"